### PR TITLE
Update locktail_rotate.sh

### DIFF
--- a/locktail_rotate.sh
+++ b/locktail_rotate.sh
@@ -15,7 +15,7 @@ do
     # echo $CURRENT_TARGET
     if [ -e ${CURRENT_TARGET} ]; then
         IO=`stat -c %i ${CURRENT_TARGET}`
-        tail -f ${CURRENT_TARGET} 2> /dev/null & echo $! > ${PID};
+        tail -f ${CURRENT_TARGET} 2> /dev/null >1 & echo $! > ${PID};
     fi
     
     # as long as the file exists and the inode number did not change


### PR DESCRIPTION
flume1.6.0, I tried, it's work. if don't use `>1`, the log doesn't send out. Maybe my flume version is too low or for other reasons, but it works. ^_^